### PR TITLE
Allow for more than 1000 Max characters to be printed in Exercise 1.17 Chapter 1

### DIFF
--- a/chapter01/1-17.c
+++ b/chapter01/1-17.c
@@ -2,14 +2,14 @@
  * Exercise 1-17. Write a program to print all input lines that are longer than
  * 80 characters.
  *
- * By Faisal Saadatmand
+ * By jerryq0101
  */
 
 #include <stdio.h>
 
-#define MAXLEN 1000    /* maximum input line length */
 #define NCHARS 80       /* number of characters per line,
 						   including the newline character */
+#define THRES 83
 
 /* functions */
 int getLine(char [], int);
@@ -34,11 +34,19 @@ int getLine(char s[], int lim)
 
 int main(void)
 {
-	int  len;                /* current line length */
-	char line[MAXLEN];       /* current input line */
+    int len, nextLen;
+    char first[THRES];
+    char continuous[THRES];
 
-	while ((len = getLine(line, MAXLEN)) > 0)
-		if (len > NCHARS)
-			printf("%s", line);
-	return 0;
+    while ((len = my_getline(first, THRES)) > 0) {
+        if (len == THRES-1) {
+            printf("%s", first);
+            nextLen = THRES-1;
+            while (nextLen == THRES-1) {
+                nextLen = my_getline(continuous, THRES);
+                printf("%s", continuous);
+            }
+        }
+        len = 0;
+    }
 }

--- a/chapter01/1-17.c
+++ b/chapter01/1-17.c
@@ -38,12 +38,12 @@ int main(void)
     char first[THRES];
     char continuous[THRES];
 
-    while ((len = my_getline(first, THRES)) > 0) {
+    while ((len = getline(first, THRES)) > 0) {
         if (len == THRES-1) {
             printf("%s", first);
             nextLen = THRES-1;
             while (nextLen == THRES-1) {
-                nextLen = my_getline(continuous, THRES);
+                nextLen = getline(continuous, THRES);
                 printf("%s", continuous);
             }
         }


### PR DESCRIPTION
Currently each line only allows for 1000 max chars for printing.

The new implementation allows any arbitrary amount of characters on each line to be printed.

Please let me know if this solution is faulty if there are better solutions.

I tested via an exit char in terminal inputs.
e.g. 
# define EXIT_CHAR '~'
